### PR TITLE
Changed the way how trailing slash was checked.

### DIFF
--- a/dist/resource-url.js
+++ b/dist/resource-url.js
@@ -8,9 +8,9 @@ function checkURL(ast, file, preferred, done) {
     var nodeUrl = node.url;
     if (nodeUrl) {
       var parsed = url.parse(nodeUrl);
-      var target = parsed.protocol + '//' + parsed.host;
+      var target = parsed.href;
 
-      if (nodeUrl === target + '/') {
+      if (target.endsWith('/')) {
         file.warn('Remove trailing slash (' + target + ')', node);
       }
     }

--- a/lib/resource-url.js
+++ b/lib/resource-url.js
@@ -6,9 +6,9 @@ function checkURL(ast, file, preferred, done) {
     const nodeUrl = node.url;
     if (nodeUrl) {
       const parsed = url.parse(nodeUrl);
-      const target = parsed.protocol + '//' + parsed.host;
+      const target = parsed.href;
 
-      if (nodeUrl === target + '/') {
+      if (target.endsWith('/')) {
         file.warn('Remove trailing slash (' + target + ')', node);
       }
     }

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "remark": "^4.2.2"
   },
   "devDependencies": {
+    "babel-cli": "^6.9.0",
     "babel-core": "^6.3.17",
     "babel-eslint": "^5.0.0-beta6",
     "babel-preset-es2015": "^6.3.13",


### PR DESCRIPTION
Also added `babel-cli` into `devDependencies` since `npm run build` was failing without it.

References: https://github.com/vhf/remark-lint-no-url-trailing-slash/issues/3
